### PR TITLE
feat: Add metric unit conversions for height and weight

### DIFF
--- a/Controllers/WrestlerController.cs
+++ b/Controllers/WrestlerController.cs
@@ -17,14 +17,14 @@ namespace wwe_universe_manager.Controllers
         }
 
         [HttpGet()]
-        public async Task<ActionResult<ResponseModel<List<WrestlerModel>>>> ListWrestlers()
+        public async Task<ActionResult<ResponseModel<List<ResponseWrestlerDto>>>> ListWrestlers()
         {
             var wrestlers = await _wrestlerInterface.ListWrestlers();
             return Ok(wrestlers);
         }
 
         [HttpGet("{id}")]
-        public async Task<ActionResult<WrestlerModel>> GetWrestlerById(long id)
+        public async Task<ActionResult<ResponseWrestlerDto>> GetWrestlerById(long id)
         {
             var wrestler = await _wrestlerInterface.FindWrestlerById(id);
             if (wrestler == null)
@@ -63,7 +63,7 @@ namespace wwe_universe_manager.Controllers
                 return BadRequest("Patch document cannot be null");
             }
 
-            var wrestlerToEdit = await _wrestlerInterface.FindWrestlerById(id);
+            var wrestlerToEdit = await _wrestlerInterface.FindWrestlerModelById(id);
 
             if(wrestlerToEdit == null)
             {

--- a/Dto/Wrestler/CreateWrestlerDto.cs
+++ b/Dto/Wrestler/CreateWrestlerDto.cs
@@ -3,8 +3,9 @@
     public class CreateWrestlerDto
     {
         public required string Name { get; set; }
-        public int Height { get; set; }
-        public int Weight { get; set; }
+        public int HeightInFeet { get; set; }
+        public int HeightInInches { get; set; }
+        public int WeightInPounds { get; set; }
         public DateOnly BirthDate { get; set; }
     }
 }

--- a/Dto/Wrestler/EditWrestlerDto.cs
+++ b/Dto/Wrestler/EditWrestlerDto.cs
@@ -1,9 +1,0 @@
-﻿namespace wwe_universe_manager.Dto.Wrestler
-{
-    public class EditWrestlerDto
-    {
-        public required string Name { get; set; }
-        public int Height { get; set; }
-        public int Weight { get; set; }
-    }
-}

--- a/Dto/Wrestler/ResponseWrestlerDto.cs
+++ b/Dto/Wrestler/ResponseWrestlerDto.cs
@@ -1,0 +1,12 @@
+﻿namespace wwe_universe_manager.Dto.Wrestler
+{
+    public class ResponseWrestlerDto
+    {
+        public long Id { get; set; }
+        public required string Name { get; set; }
+        public int Age { get; set; }
+        public double WeightInKg { get; set; }
+        public double HeightInCm { get; set; }
+        public required string HeightFormatted { get; set; }
+    }
+}

--- a/Migrations/20251003124614_UpdateWrestlerHeightToFeetAndInches.Designer.cs
+++ b/Migrations/20251003124614_UpdateWrestlerHeightToFeetAndInches.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using wwe_universe_manager.Data;
 
@@ -11,9 +12,11 @@ using wwe_universe_manager.Data;
 namespace wwe_universe_manager.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251003124614_UpdateWrestlerHeightToFeetAndInches")]
+    partial class UpdateWrestlerHeightToFeetAndInches
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20251003124614_UpdateWrestlerHeightToFeetAndInches.cs
+++ b/Migrations/20251003124614_UpdateWrestlerHeightToFeetAndInches.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace wwe_universe_manager.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateWrestlerHeightToFeetAndInches : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "Weight",
+                table: "Wrestler",
+                newName: "WeightInPounds");
+
+            migrationBuilder.RenameColumn(
+                name: "Height",
+                table: "Wrestler",
+                newName: "HeightInInches");
+
+            migrationBuilder.AddColumn<int>(
+                name: "HeightInFeet",
+                table: "Wrestler",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HeightInFeet",
+                table: "Wrestler");
+
+            migrationBuilder.RenameColumn(
+                name: "WeightInPounds",
+                table: "Wrestler",
+                newName: "Weight");
+
+            migrationBuilder.RenameColumn(
+                name: "HeightInInches",
+                table: "Wrestler",
+                newName: "Height");
+        }
+    }
+}

--- a/Models/WrestlerModel.cs
+++ b/Models/WrestlerModel.cs
@@ -1,4 +1,5 @@
-﻿using wwe_universe_manager.Interfaces;
+﻿using System.Text.Json.Serialization;
+using wwe_universe_manager.Interfaces;
 
 namespace wwe_universe_manager.Models
 {
@@ -6,8 +7,12 @@ namespace wwe_universe_manager.Models
     {
         public long Id { get; set; }
         public required string Name { get; set; }
-        public int Height { get; set; }
-        public int Weight { get; set; }
+        [JsonIgnore]
+        public int HeightInFeet { get; set; }
+        [JsonIgnore]
+        public int HeightInInches { get; set; }
+        [JsonIgnore]
+        public int WeightInPounds { get; set; }
         public DateOnly BirthDate { get; set; }
         public DateTimeOffset CreatedAt { get; set; }
         public DateTimeOffset LastUpdatedAt { get; set; }
@@ -23,6 +28,41 @@ namespace wwe_universe_manager.Models
                     age--;
                 }
                 return age;
+            }
+        }
+
+        public double WeightInKg
+        {
+            get
+            {
+                const double poundsToKg = 0.45359237;
+                return Math.Round(WeightInPounds * poundsToKg, 2);
+            }
+        }
+
+        [JsonIgnore]
+        public int TotalHeightInInches
+        {
+            get
+            {
+                return (HeightInFeet * 12) + HeightInInches;
+            }
+        }
+
+        public double HeightInCm
+        {
+            get
+            {
+                const double inchesToCm = 2.54;
+                return Math.Round(TotalHeightInInches * inchesToCm, 2);
+            }
+        }
+
+        public string HeightFormatted
+        {
+            get
+            {
+                return $"{HeightInFeet}' {HeightInInches}";
             }
         }
     }

--- a/Services/Wrestler/IWrestlerInterface.cs
+++ b/Services/Wrestler/IWrestlerInterface.cs
@@ -5,8 +5,9 @@ namespace wwe_universe_manager.Services.Wrestler
 {
     public interface IWrestlerInterface
     {
-        Task<List<WrestlerModel>> ListWrestlers();
-        Task<WrestlerModel?> FindWrestlerById(long wrestlerId);
+        Task<List<ResponseWrestlerDto>> ListWrestlers();
+        Task<ResponseWrestlerDto?> FindWrestlerById(long wrestlerId);
+        Task<WrestlerModel?> FindWrestlerModelById(long wrestlerId);
         Task<WrestlerModel> CreateWrestler(CreateWrestlerDto wrestlerDto);
         Task<WrestlerModel?> DeleteWrestler(long wrestlerId);
         Task<int> SaveChangesAsync();

--- a/Services/Wrestler/WrestlerService.cs
+++ b/Services/Wrestler/WrestlerService.cs
@@ -18,8 +18,9 @@ namespace wwe_universe_manager.Services.Wrestler
             var wrestler = new WrestlerModel()
             {
                 Name = wrestlerDto.Name,
-                Height = wrestlerDto.Height,
-                Weight = wrestlerDto.Weight,
+                HeightInFeet = wrestlerDto.HeightInFeet,
+                HeightInInches = wrestlerDto.HeightInInches,
+                WeightInPounds = wrestlerDto.WeightInPounds,
                 BirthDate = wrestlerDto.BirthDate
             };
 
@@ -43,14 +44,45 @@ namespace wwe_universe_manager.Services.Wrestler
             return wrestlerToDelete;
         }
 
-        public async Task<WrestlerModel?> FindWrestlerById(long wrestlerId)
+        public async Task<ResponseWrestlerDto?> FindWrestlerById(long wrestlerId)
+        {
+            var wrestler = await _appDbContext.Wrestler.FirstOrDefaultAsync(wrestler => wrestler.Id == wrestlerId);
+            
+            if(wrestler == null)
+            {
+                return null;
+            }
+
+            var wrestlerDto = new ResponseWrestlerDto
+            {
+                Id = wrestler.Id,
+                Name = wrestler.Name,
+                Age = wrestler.Age,
+                WeightInKg = wrestler.WeightInKg,
+                HeightInCm = wrestler.HeightInCm,
+                HeightFormatted = wrestler.HeightFormatted,
+            };
+
+            return wrestlerDto;
+        }
+
+        public async Task<WrestlerModel?> FindWrestlerModelById(long wrestlerId)
         {
             return await _appDbContext.Wrestler.FirstOrDefaultAsync(wrestler => wrestler.Id == wrestlerId);
         }
 
-        public async Task<List<WrestlerModel>> ListWrestlers()
+        public async Task<List<ResponseWrestlerDto>> ListWrestlers()
         {
-            var wrestlers = await _appDbContext.Wrestler.ToListAsync();
+            var wrestlers = await _appDbContext.Wrestler.Select(wrestler => new ResponseWrestlerDto
+            {
+                Id = wrestler.Id,
+                Name = wrestler.Name,
+                Age = wrestler.Age,
+                WeightInKg = wrestler.WeightInKg,
+                HeightInCm = wrestler.HeightInCm,
+                HeightFormatted = wrestler.HeightFormatted,
+            }).ToListAsync();
+
             return wrestlers;
         }
 


### PR DESCRIPTION
The wrestler model now stores height (feet/inches) and weight (pounds) in imperial units to match the game's standard.

New calculated properties have been added to expose metric conversions (cm/kg) and formatted strings to the API, centralizing the conversion logic in the back-end.